### PR TITLE
Allow 0x1B for control char Escape need for TC Freemen

### DIFF
--- a/file_proc.pas
+++ b/file_proc.pas
@@ -37,7 +37,8 @@ const
     10, //LF
     13, //CR
     12, //FormFeed
-    26 //EOF
+    26, //EOF
+    27 //Escape
     ];
 begin
   Result:= (n < 32) and not (byte(n) in cAllowedControlChars);


### PR DESCRIPTION
Allow 0x1B for control char Escape need for TC Freemen