### PR TITLE
Add app version display to options window title

### DIFF
--- a/form_main.pas
+++ b/form_main.pas
@@ -31,7 +31,8 @@ uses
   proc_themes,
   form_options,
   form_find,
-  FileUtil;
+  FileUtil,
+  version;
 
 const
   cEditorIsReadOnly = false;
@@ -1030,6 +1031,7 @@ begin
   F:= TfmOptions.Create(nil);
   try
     F.ed:= Self.ed;
+    F.Caption:= F.Caption + ' (v' + cAppVersion + ')';
     F.ShowModal;
     SaveOptions;
     UpdateStatusbar;

--- a/version.pas
+++ b/version.pas
@@ -1,0 +1,12 @@
+unit version;  
+
+{$mode objfpc}{$H+}
+  
+interface
+
+const
+  cAppVersion = '1.8.3.0';
+ 
+implementation  
+ 
+end.


### PR DESCRIPTION
Hi,
I've added a small quality-of-life enhancement to display the current version of Cuda Lister so it's easier to see if the plugin is up to date. 
![image](https://github.com/Alexey-T/CudaLister/assets/31290050/2b2711b3-5a86-45ac-9fec-8452d2b1e21a)
